### PR TITLE
Fix Homer search: correct src/dst IP field map + add Type selector

### DIFF
--- a/app/routes/homer.py
+++ b/app/routes/homer.py
@@ -526,6 +526,7 @@ async def homer_call_detail(
     id: Optional[int] = None,
     ts: Optional[int] = None,
     tab: str = "flow",
+    profile: Optional[str] = None,
 ):
     """Homer call detail page with 5 tabs."""
     if not _HOMER_ENABLED():
@@ -535,11 +536,14 @@ async def homer_call_detail(
     error: Optional[str] = None
     detail: dict = {}
     latency_ms: float = 0.0
+    profile = _normalize_profile(profile)
 
     try:
         hc: HomerClient = await get_homer_client()
         ts_ms = ts or int(time.time() * 1000)
-        transaction, latency_ms = await hc.get_call_transaction(callid, id or 0, ts_ms)
+        transaction, latency_ms = await hc.get_call_transaction(
+            callid, id or 0, ts_ms, profile=profile
+        )
         detail = _build_call_detail(transaction)
     except Exception as exc:
         error = str(exc)
@@ -554,6 +558,7 @@ async def homer_call_detail(
             "record_id": id,
             "ts": ts,
             "tab": tab,
+            "profile": profile,
             "latency_ms": round(latency_ms, 1),
             "error": error,
             **detail,
@@ -570,6 +575,7 @@ async def homer_call_export(
     callid: str,
     id: Optional[int] = None,
     ts: Optional[int] = None,
+    profile: Optional[str] = None,
 ):
     """Download raw transaction JSON for a call."""
     if not _HOMER_ENABLED():
@@ -578,7 +584,9 @@ async def homer_call_export(
     try:
         hc: HomerClient = await get_homer_client()
         ts_ms = ts or int(time.time() * 1000)
-        transaction, _ = await hc.get_call_transaction(callid, id or 0, ts_ms)
+        transaction, _ = await hc.get_call_transaction(
+            callid, id or 0, ts_ms, profile=_normalize_profile(profile)
+        )
     except Exception as exc:
         return JSONResponse({"error": str(exc)}, status_code=500)
 

--- a/app/routes/homer.py
+++ b/app/routes/homer.py
@@ -11,7 +11,13 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from app.security.basic_auth import requires_admin, get_current_user
 from app.security.csrf import get_csrf_token
-from app.services.homer import HomerClient, get_homer_client
+from app.services.homer import (
+    DEFAULT_PROFILE,
+    SUPPORTED_PROFILES,
+    HomerClient,
+    _normalize_profile,
+    get_homer_client,
+)
 
 router = APIRouter()
 
@@ -431,6 +437,7 @@ async def homer_index(
     from_tag: Optional[str] = None,
     to_tag: Optional[str] = None,
     hours: int = 168,
+    profile: Optional[str] = None,
     search: Optional[str] = None,  # present when the form was submitted
 ):
     """Homer SIP search page."""
@@ -442,6 +449,7 @@ async def homer_index(
     calls: list[dict] = []
     latency_ms: float = 0.0
     searched = False
+    profile = _normalize_profile(profile)
 
     filters = {
         "callid": callid or "",
@@ -472,7 +480,10 @@ async def homer_index(
             ]
             callid_only = bool(filters["callid"]) and not any(other_filters)
 
-            if callid_only:
+            if callid_only and profile == DEFAULT_PROFILE:
+                # call/transaction endpoint is call-profile-specific; only use
+                # the unbounded callid lookup when we're searching the call
+                # table. Other profiles fall through to the standard search.
                 _THIRTY_DAYS_MS = 30 * 24 * 3_600_000
                 transaction, latency_ms = await hc.get_call_transaction(
                     filters["callid"], 0, now_ms, window_ms=_THIRTY_DAYS_MS
@@ -481,7 +492,9 @@ async def homer_index(
                 calls = [summary] if summary else []
             else:
                 time_from_ms = now_ms - hours * 3_600_000
-                records, latency_ms = await hc.search_calls(filters, time_from_ms, now_ms)
+                records, latency_ms = await hc.search_calls(
+                    filters, time_from_ms, now_ms, profile=profile
+                )
                 calls = _group_calls(records)
         except Exception as exc:
             error = str(exc)
@@ -494,6 +507,8 @@ async def homer_index(
             "csrf_token": get_csrf_token(request),
             "filters": filters,
             "hours": hours,
+            "profile": profile,
+            "profile_choices": SUPPORTED_PROFILES,
             "calls": calls,
             "latency_ms": round(latency_ms, 1),
             "searched": searched,

--- a/app/services/homer.py
+++ b/app/services/homer.py
@@ -70,13 +70,20 @@ def _build_homer_filters(filters: dict) -> list[dict]:
 
     An empty list [] means "no filter" (return all records).
     """
+    # Homer 7 splits SIP metadata between two JSONB columns on hep_proto_1_*:
+    #   - data_header     → SIP-parsed fields (callid, from_user, method, …)
+    #                        keyed in snake_case
+    #   - protocol_header → packet-level fields (srcIp, dstIp, srcPort, …)
+    #                        keyed in camelCase
+    # Filtering on the wrong column silently returns 0 rows because Homer's
+    # WHERE clause becomes a JSONB lookup against a non-existent key.
     field_map = {
         "callid":    "data_header.callid",
         "from_user": "data_header.from_user",
         "to_user":   "data_header.to_user",
         "method":    "data_header.method",
-        "source_ip": "data_header.src_ip",
-        "dst_ip":    "data_header.dst_ip",
+        "source_ip": "protocol_header.srcIp",
+        "dst_ip":    "protocol_header.dstIp",
         "from_tag":  "data_header.from_tag",
         "to_tag":    "data_header.to_tag",
     }
@@ -88,12 +95,25 @@ def _build_homer_filters(filters: dict) -> list[dict]:
     return result
 
 
+SUPPORTED_PROFILES: tuple[str, ...] = ("call", "registration", "default")
+DEFAULT_PROFILE = "call"
+
+
+def _normalize_profile(profile: str | None) -> str:
+    """Coerce a user-supplied profile string to one of SUPPORTED_PROFILES."""
+    if not profile:
+        return DEFAULT_PROFILE
+    p = profile.strip().lower()
+    return p if p in SUPPORTED_PROFILES else DEFAULT_PROFILE
+
+
 async def search_calls(
     url: str,
     token: str,
     filters: dict,
     time_from_ms: int,
     time_to_ms: int,
+    profile: str = DEFAULT_PROFILE,
     limit: int = 200,
 ) -> tuple[list[dict], float]:
     """
@@ -101,19 +121,26 @@ async def search_calls(
 
     filters: dict with optional keys callid, from_user, to_user, method,
              source_ip, dst_ip, from_tag, to_tag.
+    profile: Homer protocol profile to search. Homer 7 stores SIP traffic in
+             separate tables per transaction type:
+               - "call"         → hep_proto_1_call (INVITE/BYE/CANCEL/…)
+               - "registration" → hep_proto_1_registration (REGISTER)
+               - "default"      → hep_proto_1_default (OPTIONS/MESSAGE/…)
+             Defaults to "call" for back-compat.
     """
+    profile = _normalize_profile(profile)
     payload = {
         "config": {
             "protocol_id": {"name": "SIP", "value": 1},
-            "protocol_profile": {"name": "call", "value": "call"},
+            "protocol_profile": {"name": profile, "value": profile},
             "searchbutton": False,
-            "title": "CALL 2 SIP SEARCH",
+            "title": f"SIP {profile.upper()} SEARCH",
         },
         "param": {
             "transaction": {},
             "limit": limit,
             "orlogic": False,
-            "search": {"1_call": _build_homer_filters(filters)},
+            "search": {f"1_{profile}": _build_homer_filters(filters)},
             "location": {},
             "timezone": {"value": -180, "name": "Local"},
         },
@@ -209,9 +236,12 @@ class HomerClient:
         filters: dict,
         time_from_ms: int,
         time_to_ms: int,
+        profile: str = DEFAULT_PROFILE,
         limit: int = 200,
     ) -> tuple[list[dict], float]:
-        return await search_calls(self.url, self.token, filters, time_from_ms, time_to_ms, limit)
+        return await search_calls(
+            self.url, self.token, filters, time_from_ms, time_to_ms, profile, limit
+        )
 
     async def get_call_transaction(
         self, callid: str, record_id: int | str, ts_ms: int, window_ms: int = 3_600_000

--- a/app/services/homer.py
+++ b/app/services/homer.py
@@ -178,6 +178,13 @@ async def search_calls(
     return records, latency_ms
 
 
+_TRANSACTION_FLAGS = {
+    "call":         {"call": True,  "registration": False, "rest": False},
+    "registration": {"call": False, "registration": True,  "rest": False},
+    "default":      {"call": False, "registration": False, "rest": True},
+}
+
+
 async def get_call_transaction(
     url: str,
     token: str,
@@ -185,18 +192,25 @@ async def get_call_transaction(
     record_id: int | str,
     ts_ms: int,
     window_ms: int = 3_600_000,
+    profile: str = DEFAULT_PROFILE,
 ) -> tuple[dict, float]:
     """POST /api/v3/call/transaction and return (response_dict, latency_ms).
 
     window_ms controls the half-width of the timestamp search window around ts_ms.
     Use a wider value (e.g. 30 * 24 * 3_600_000) when the call timestamp is unknown.
+
+    profile selects which Homer 7 transaction table the lookup hits. Setting
+    the wrong profile returns an empty message list, which renders as a blank
+    flow diagram — REGISTERs in particular live in `hep_proto_1_registration`,
+    not `hep_proto_1_call`.
     """
+    profile = _normalize_profile(profile)
     payload = {
         "param": {
-            "transaction": {"call": True, "registration": False, "rest": False},
+            "transaction": _TRANSACTION_FLAGS[profile],
             "limit": 200,
             "orlogic": False,
-            "search": {"1_call": {"id": record_id, "callid": [callid]}},
+            "search": {f"1_{profile}": {"id": record_id, "callid": [callid]}},
             "location": {},
             "timezone": {"value": -180, "name": "Local"},
         },
@@ -244,9 +258,16 @@ class HomerClient:
         )
 
     async def get_call_transaction(
-        self, callid: str, record_id: int | str, ts_ms: int, window_ms: int = 3_600_000
+        self,
+        callid: str,
+        record_id: int | str,
+        ts_ms: int,
+        window_ms: int = 3_600_000,
+        profile: str = DEFAULT_PROFILE,
     ) -> tuple[dict, float]:
-        return await get_call_transaction(self.url, self.token, callid, record_id, ts_ms, window_ms)
+        return await get_call_transaction(
+            self.url, self.token, callid, record_id, ts_ms, window_ms, profile
+        )
 
 
 async def get_homer_client() -> HomerClient:

--- a/app/templates/homer/call.html.j2
+++ b/app/templates/homer/call.html.j2
@@ -216,33 +216,33 @@
 <ul class="nav nav-tabs mb-0" id="homer-tabs" role="tablist">
     <li class="nav-item">
         <a class="nav-link {% if tab == 'flow' %}active{% endif %}"
-           href="?id={{ record_id }}&ts={{ ts }}&tab=flow">
+           href="?id={{ record_id }}&ts={{ ts }}&profile={{ profile }}&tab=flow">
             <i class="bi bi-diagram-3 me-1"></i>Flow
         </a>
     </li>
     <li class="nav-item">
         <a class="nav-link {% if tab == 'messages' %}active{% endif %}"
-           href="?id={{ record_id }}&ts={{ ts }}&tab=messages">
+           href="?id={{ record_id }}&ts={{ ts }}&profile={{ profile }}&tab=messages">
             <i class="bi bi-envelope me-1"></i>Messages
             {% if total_messages %}<span class="badge bg-secondary ms-1">{{ total_messages }}</span>{% endif %}
         </a>
     </li>
     <li class="nav-item">
         <a class="nav-link {% if tab == 'session' %}active{% endif %}"
-           href="?id={{ record_id }}&ts={{ ts }}&tab=session">
+           href="?id={{ record_id }}&ts={{ ts }}&profile={{ profile }}&tab=session">
             <i class="bi bi-info-circle me-1"></i>Session Info
         </a>
     </li>
     <li class="nav-item">
         <a class="nav-link {% if tab == 'logs' %}active{% endif %}"
-           href="?id={{ record_id }}&ts={{ ts }}&tab=logs">
+           href="?id={{ record_id }}&ts={{ ts }}&profile={{ profile }}&tab=logs">
             <i class="bi bi-journal-text me-1"></i>Logs
             {% if logs is defined and logs %}<span class="badge bg-secondary ms-1">{{ logs | length }}</span>{% endif %}
         </a>
     </li>
     <li class="nav-item">
         <a class="nav-link {% if tab == 'export' %}active{% endif %}"
-           href="?id={{ record_id }}&ts={{ ts }}&tab=export">
+           href="?id={{ record_id }}&ts={{ ts }}&profile={{ profile }}&tab=export">
             <i class="bi bi-download me-1"></i>Export
         </a>
     </li>

--- a/app/templates/homer/call.html.j2
+++ b/app/templates/homer/call.html.j2
@@ -586,7 +586,7 @@
                     <dt class="col-4 text-secondary">Logs</dt>
                     <dd class="col-8">{{ (logs | length) if logs else 0 }}</dd>
                 </dl>
-                <a href="/homer/call/{{ callid | urlencode }}/export.json?id={{ record_id }}&ts={{ ts }}"
+                <a href="/homer/call/{{ callid | urlencode }}/export.json?id={{ record_id }}&ts={{ ts }}&profile={{ profile }}"
                    class="btn btn-primary" download>
                     <i class="bi bi-download me-2"></i>Download JSON
                 </a>

--- a/app/templates/homer/index.html.j2
+++ b/app/templates/homer/index.html.j2
@@ -115,6 +115,19 @@
                             <input type="text" name="to_tag" class="form-control form-control-sm"
                                    value="{{ filters.to_tag }}" placeholder="">
                         </div>
+                        <div class="mb-2">
+                            <label class="form-label small mb-1">Type</label>
+                            <select name="profile" class="form-select form-select-sm">
+                                {% for p in profile_choices %}
+                                <option value="{{ p }}" {% if profile == p %}selected{% endif %}>
+                                    {%- if p == "call" -%}Call (INVITE / BYE)
+                                    {%- elif p == "registration" -%}Registration (REGISTER)
+                                    {%- elif p == "default" -%}Other (OPTIONS / MESSAGE / …)
+                                    {%- else -%}{{ p|capitalize }}{%- endif -%}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </div>
                         <div class="mb-3">
                             <label class="form-label small mb-1">Time Range</label>
                             <select name="hours" class="form-select form-select-sm">

--- a/app/templates/homer/index.html.j2
+++ b/app/templates/homer/index.html.j2
@@ -196,7 +196,7 @@
                                         onclick="navigator.clipboard.writeText('{{ call.callid }}')">
                                     <i class="bi bi-clipboard"></i>
                                 </button>
-                                <a href="/homer/call/{{ call.callid | urlencode }}?id={{ call.id }}&ts={{ call.create_date }}"
+                                <a href="/homer/call/{{ call.callid | urlencode }}?id={{ call.id }}&ts={{ call.create_date }}&profile={{ profile }}"
                                    title="{{ call.callid }}">
                                     {{ call.callid[:40] }}{% if call.callid|length > 40 %}…{% endif %}
                                 </a>


### PR DESCRIPTION
Two bugs in the `/homer` search route silently dropped whole categories of search results because the request was wired against the wrong slice of Homer 7's schema.

### 1. Source / Destination IP filters always returned 0 rows

`_build_homer_filters` mapped `source_ip` / `dst_ip` to:

```python
"source_ip": "data_header.src_ip",
"dst_ip":    "data_header.dst_ip",
```

But Homer 7 stores L3 addresses under **`protocol_header.srcIp` / `protocol_header.dstIp`** (camelCase). `data_header` only holds SIP-parsed fields (`callid`, `from_user`, `method`, …). Filtering on the wrong JSONB column silently returns nothing.

Notably, this file's own result rendering in `app/routes/homer.py` already reads `srcIp` / `dstIp`:

```python
"src_ip": invite.get("srcIp") or invite.get("source_ip", ""),
"dst_ip": invite.get("dstIp") or invite.get("destination_ip", ""),
```

— so the same module was writing the filter as one path and reading the result back from another. Fixed the field map to match where the data actually lives.

### 2. REGISTER / OPTIONS / MESSAGE etc. were unsearchable

The search request hard-coded the protocol profile:

```python
"protocol_profile": {"name": "call", "value": "call"},
...
"search": {"1_call": _build_homer_filters(filters)},
```

This pins the query to `hep_proto_1_call`. Homer 7 splits SIP into three tables by transaction type:

| Profile | Table | Methods |
|---|---|---|
| `call` | `hep_proto_1_call` | INVITE / BYE / CANCEL / 200-for-INVITE … |
| `registration` | `hep_proto_1_registration` | REGISTER |
| `default` | `hep_proto_1_default` | OPTIONS / MESSAGE / NOTIFY … |

`method=REGISTER` against the call table is always empty even when REGISTER traffic is being captured fine.

Added a `Type` dropdown (Call / Registration / Other) plumbed through routes → service → Homer payload. Defaults to `call` so existing bookmarks and links behave unchanged. The unbounded `call/transaction` callid shortcut is now skipped for non-call profiles, since that endpoint is call-table-specific.

### Diff summary

- `app/services/homer.py`
  - `_build_homer_filters`: fix `source_ip` / `dst_ip` field map
  - Add `SUPPORTED_PROFILES`, `DEFAULT_PROFILE`, `_normalize_profile`
  - `search_calls` / `HomerClient.search_calls`: accept `profile`, use it for `protocol_profile` and the `search` key
- `app/routes/homer.py`
  - Add `profile` query param to `homer_index`
  - Pass through to `hc.search_calls`; skip callid-shortcut for non-call profiles
  - Expose `profile` + `profile_choices` in template context
- `app/templates/homer/index.html.j2`
  - Add `<select name="profile">` before the Time Range select

### Testing

Tested against a Homer 7 deployment ingesting from heplify-server:

- `?src_ip=<X>` now returns rows for any IP that appears in the unfiltered result list (previously empty).
- `?profile=registration&method=REGISTER` returns REGISTER traffic from `hep_proto_1_registration` (previously empty).
- Default (`profile` omitted) behaves identically to before for call-profile searches.
- Callid-only search still uses the unbounded `call/transaction` endpoint when `profile=call`.

Happy to adjust scope or split into two PRs if you'd prefer the IP fix to land separately from the Type selector.